### PR TITLE
[BUGFIX] sanitize search string to prevent cross-site scripting.

### DIFF
--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -14,7 +14,7 @@ class SearchController extends ActionController
 {
     public function searchAction()
     {
-        $searchString = $this->request->getQueryParams()[($this->settings['parameters']['search'] ?? 'q')];
+        $searchString = htmlspecialchars(strip_tags($this->request->getQueryParams()[($this->settings['parameters']['search'] ?? 'q')]), ENT_QUOTES, 'UTF-8');
         $currentPage = $this->request->getQueryParams()[($this->settings['parameters']['page'] ?? 'p')];
         $currentPage = max(1, $currentPage ? (int)$currentPage : 1);
         $category = $this->request->getQueryParams()[($this->settings['parameters']['category'] ?? 'c')];


### PR DESCRIPTION
The variable $searchString appears to be not sanitized after being set from the request parameter. As this variable is also passed to the view, its content gets rendered, causing JavaScript embedded in script tags to be executed by the browser.

This fix adds functions htmlspecialchars and strip_tags to remove any HTML from the search string before it's processed.

Credit goes to my work colleague, Marlin, for discovering this vulnerability in one of our customer projects. 